### PR TITLE
Updated DE Translation and fixed Typo in EN

### DIFF
--- a/locale/de/loader_modernized.cfg
+++ b/locale/de/loader_modernized.cfg
@@ -66,6 +66,8 @@ mdrn-double-recipe=Doppelte Belader
 mdrn-migrate-from-miniloaders=Migration von Miniloaders
 mdrn-enable-chute=Laderutsche einschalten
 mdrn-enable-stacking=Bandstapelung einschalten
+mdrn-cheap-stacking=Günstigere Stapel-Belader
+mdrn-use-aai-graphics=Benutze AAI Loaders Grafik
 
 [mod-setting-description]
 mdrn-use-electricity=Wenn diese Einstellung eingeschaltet ist, benötigen die Belader Strom.
@@ -73,6 +75,8 @@ mdrn-double-recipe=Verdoppeln Sie die Rezepturkosten und stellen Sie jeweils 2 L
 mdrn-migrate-from-miniloaders=Versucht gebaute Minibelader auf die aktuellen Belader zu migrieren. Belader im Inventar und in Containern werden verloren gehen. Rezepte in den Montagemaschinen werden zurückgesetzt.
 mdrn-enable-chute=Schaltet das Rezept für die langsame Laderutsche ein.
 mdrn-enable-stacking=Schaltet die Bandstapelung zusammen mit der Stapeltechnologie ein.
+mdrn-cheap-stacking=Benutzt eine billigere Variante des Rezeptes, ohne den Stapelgreifarm. (vorrausgesetzt das Bandstapeln der Belader ist eingeschaltet)
+mdrn-use-aai-graphics=AAI Loaders wurde erkannt.\nBenutzt nur die Grafik von AAI Loaders für Loaders Modernized.\n\nWenn du dies ausschaltest und neustartest, solltest du in der Lage sein sowohl Loaders Modernized als auch AAI Loaders zu verwenden.
 
 [string-mod-setting]
 mdrn-enable-stacking-none=Keine

--- a/locale/en/loader_modernized.cfg
+++ b/locale/en/loader_modernized.cfg
@@ -59,7 +59,7 @@ mdrn-double-recipe=Double recipe
 mdrn-migrate-from-miniloaders=Migrate from Miniloaders
 mdrn-enable-chute=Enable chute loader
 mdrn-enable-stacking=Enable belt stacking
-mdrn-cheap-stacking=Cheaper stacking loaers
+mdrn-cheap-stacking=Cheaper stacking loaders
 mdrn-use-aai-graphics=Use AAI Loaders graphics
 
 [mod-setting-description]


### PR DESCRIPTION
Typo:
mdrn-cheap-stacking=Cheaper stacking loaers -> mdrn-cheap-stacking=Cheaper stacking loaders

