### PR TITLE
Fix `factorio-mods-localization.json`

### DIFF
--- a/factorio-mods-localization.json
+++ b/factorio-mods-localization.json
@@ -1,3 +1,3 @@
 {
-    "branch": "i10n"
+    "branch": "l10n"
 }


### PR DESCRIPTION
Fixed a typo in branch name in [factorio-mods-localization](https://github.com/dima74/factorio-mods-localization) config